### PR TITLE
✨ Add `autolink_ext`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "markdown_it_pyrs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "itertools",
  "markdown-it",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "gfm-autolinks"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e759407cedde28f2324a4ce9e1b309a5730b328985c2f5482d87fd3a75535d55"
+dependencies = [
+ "once_cell",
+ "unicode_categories",
+]
+
+[[package]]
 name = "github-slugger"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +326,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "markdown-it-autolink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea23e65f2a1cd149861f2cb8c0a50c8f1f47f35d0b0706100f50e39e7c0bc52"
+dependencies = [
+ "gfm-autolinks",
+ "markdown-it",
+]
+
+[[package]]
 name = "markdown-it-footnote"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +381,7 @@ version = "0.1.0"
 dependencies = [
  "itertools",
  "markdown-it",
+ "markdown-it-autolink",
  "markdown-it-footnote",
  "markdown-it-front-matter",
  "markdown-it-heading-anchors",
@@ -820,6 +841,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unindent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 itertools = "0.11.0"
 markdown-it = "0.5.0"
+markdown-it-autolink = "0.1.0"
 markdown-it-footnote = "0.1.1"
 markdown-it-front-matter = "0.2.0"
 markdown-it-heading-anchors = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markdown_it_pyrs"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ GitHub Flavoured Markdown (<https://github.github.com/gfm>):
   | --- | --- |
   | baz | bim |
   ```
-- `linkify`: Automatically linkify URLs
 - `strikethrough`: `~~strikethrough~~`
 - `tasklist`: `- [x] tasklist item`
+- `autolink_ext`: Extended autolink detection with "bare URLs" like `https://example.com` and `www.example.com`
 
 Others:
 
@@ -159,6 +159,7 @@ Others:
 - `front_matter`: YAML front matter
 - `footnote`: Pandoc-style footnotes (see <https://pandoc.org/MANUAL.html#footnotes>)
 - `heading_anchors`: Add heading anchors, with defaults like GitHub
+- `linkify`: Automatically linkify URLs with <https://crates.io/crates/linkify> (note currently this only matches URLs with a scheme, e.g. `https://example.com`)
 
 ## Development
 
@@ -185,7 +186,6 @@ Improvements:
   - footnotes with options to turn on/off inline/collect/backrefs
 
 - The `gfm` (Github Flavoured Markdown) initialisation mode needs improving
-  - `linkify` is not strictly equivalent to <https://github.github.com/gfm/#autolinks-extension->, e.g. it does not currently autolink `www.example.com`
   - Add <https://github.github.com/gfm/#disallowed-raw-html-extension->
   - heading anchors, is not strictly in the spec, but should be noted
   - Add more testing

--- a/python/markdown_it_pyrs/markdown_it_pyrs.pyi
+++ b/python/markdown_it_pyrs/markdown_it_pyrs.pyi
@@ -92,6 +92,7 @@ _PLUGIN_NAME = Literal[
     "tasklist",
     "footnote",
     "heading_anchors",
+    "autolink_ext",
 ]
 
 class MarkdownIt:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,9 @@ impl MarkdownIt {
             "heading_anchors" => {
                 markdown_it_heading_anchors::add(&mut self.parser);
             }
+            "autolink_ext" => {
+                markdown_it_autolink::add(&mut self.parser);
+            }
             _ => {
                 return {
                     Err(pyo3::exceptions::PyValueError::new_err(format!(
@@ -133,7 +136,7 @@ impl MarkdownIt {
                 markdown_it::plugins::html::add(&mut parser);
                 markdown_it::plugins::extra::tables::add(&mut parser);
                 markdown_it::plugins::extra::strikethrough::add(&mut parser);
-                markdown_it::plugins::extra::linkify::add(&mut parser);
+                markdown_it_autolink::add(&mut parser);
                 markdown_it_tasklist::add(&mut parser);
                 Ok(Self {
                     parser,
@@ -188,6 +191,7 @@ impl MarkdownIt {
             "tasklist",
             "footnote",
             "heading_anchors",
+            "autolink_ext",
         ]
         .iter()
         .map(|s| s.to_string())

--- a/tests/fixtures/autolink_ext.md
+++ b/tests/fixtures/autolink_ext.md
@@ -1,0 +1,175 @@
+The scheme http will be inserted automatically:
+<https://github.github.com/gfm/#example-622>
+.
+www.commonmark.org
+.
+<p><a href="http://www.commonmark.org">www.commonmark.org</a></p>
+.
+
+After a valid domain, zero or more non-space non-< characters may follow:
+<https://github.github.com/gfm/#example-623>
+.
+Visit www.commonmark.org/help for more information.
+.
+<p>Visit <a href="http://www.commonmark.org/help">www.commonmark.org/help</a> for more information.</p>
+.
+
+Trailing punctuation (specifically, ?, !, ., ,, :, *, _, and ~) will not be considered part of the autolink, though they may be included in the interior of the link:
+<https://github.github.com/gfm/#example-624>
+.
+Visit www.commonmark.org.
+
+Visit www.commonmark.org/a.b.
+.
+<p>Visit <a href="http://www.commonmark.org">www.commonmark.org</a>.</p>
+<p>Visit <a href="http://www.commonmark.org/a.b">www.commonmark.org/a.b</a>.</p>
+.
+
+When an autolink ends in `)`, we scan the entire autolink for the total number of parentheses. If there is a greater number of closing parentheses than opening ones, we don’t consider the unmatched trailing parentheses part of the autolink, in order to facilitate including an autolink inside a parenthesis:
+<https://github.github.com/gfm/#example-625>
+.
+www.google.com/search?q=Markup+(business)
+
+www.google.com/search?q=Markup+(business)))
+
+(www.google.com/search?q=Markup+(business))
+
+(www.google.com/search?q=Markup+(business)
+.
+<p><a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a></p>
+<p><a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a>))</p>
+<p>(<a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a>)</p>
+<p>(<a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a></p>
+.
+
+This check is only done when the link ends in a closing parentheses ), so if the only parentheses are in the interior of the autolink, no special rules are applied:
+<https://github.github.com/gfm/#example-626>
+.
+www.google.com/search?q=(business))+ok
+.
+<p><a href="http://www.google.com/search?q=(business))+ok">www.google.com/search?q=(business))+ok</a></p>
+.
+
+If an autolink ends in a semicolon (;), we check to see if it appears to resemble an entity reference; if the preceding text is & followed by one or more alphanumeric characters. If so, it is excluded from the autolink:
+<https://github.github.com/gfm/#example-627>
+.
+www.google.com/search?q=commonmark&hl=en
+
+www.google.com/search?q=commonmark&hl;
+.
+<p><a href="http://www.google.com/search?q=commonmark&amp;hl=en">www.google.com/search?q=commonmark&amp;hl=en</a></p>
+<p><a href="http://www.google.com/search?q=commonmark">www.google.com/search?q=commonmark</a>&amp;hl;</p>
+.
+
+< immediately ends an autolink.
+<https://github.github.com/gfm/#example-628>
+.
+www.commonmark.org/he<lp
+.
+<p><a href="http://www.commonmark.org/he">www.commonmark.org/he</a>&lt;lp</p>
+.
+
+An extended url autolink will be recognised when one of the schemes http://, or https://, followed by a valid domain, then zero or more non-space non-< characters according to extended autolink path validation:
+<https://github.github.com/gfm/#example-629>
+.
+http://commonmark.org
+
+(Visit https://encrypted.google.com/search?q=Markup+(business))
+.
+<p><a href="http://commonmark.org">http://commonmark.org</a></p>
+<p>(Visit <a href="https://encrypted.google.com/search?q=Markup+(business)">https://encrypted.google.com/search?q=Markup+(business)</a>)</p>
+.
+
+An extended email autolink will be recognised when an email address is recognised within any text node. Email addresses are recognised according to the following rules:
+
+- One ore more characters which are alphanumeric, or ., -, _, or +.
+- An @ symbol.
+- One or more characters which are alphanumeric, or - or _, separated by periods (.). There must be at least one period. The last character must not be one of - or _.
+
+The scheme mailto: will automatically be added to the generated link:
+<https://github.github.com/gfm/#example-630>
+.
+foo@bar.baz
+.
+<p><a href="mailto:foo@bar.baz">foo@bar.baz</a></p>
+.
+
++ can occur before the @, but not after.
+<https://github.github.com/gfm/#example-631>
+.
+hello@mail+xyz.example isn't valid, but hello+xyz@mail.example is.
+.
+<p>hello@mail+xyz.example isn't valid, but <a href="mailto:hello+xyz@mail.example">hello+xyz@mail.example</a> is.</p>
+.
+
+`.`, `-`, and `_` can occur on both sides of the `@`, but only `.` may occur at the end of the email address, in which case it will not be considered part of the address:
+<https://github.github.com/gfm/#example-632>
+TODO `_` is not supported yet (overriden by emphasis).
+.
+a.b-c-d@a.b
+
+a.b-c-d@a.b.
+
+a.b-c-d@a.b-
+
+a.b-c-d@a.b_
+.
+<p><a href="mailto:a.b-c-d@a.b">a.b-c-d@a.b</a></p>
+<p><a href="mailto:a.b-c-d@a.b">a.b-c-d@a.b</a>.</p>
+<p>a.b-c-d@a.b-</p>
+<p>a.b-c-d@a.b_</p>
+.
+
+An extended protocol autolink will be recognised when a protocol is recognised within any text node. Valid protocols are:
+- `mailto:`
+- `xmpp:`
+The scheme of the protocol will automatically be added to the generated link. All the rules of email address autolinking apply.
+<https://github.github.com/gfm/#example-633>
+.
+mailto:foo@bar.baz
+
+mailto:a.b-c_d@a.b
+
+mailto:a.b-c_d@a.b.
+
+mailto:a.b-c_d@a.b/
+
+mailto:a.b-c_d@a.b-
+
+mailto:a.b-c_d@a.b_
+
+xmpp:foo@bar.baz
+
+xmpp:foo@bar.baz.
+.
+<p><a href="mailto:foo@bar.baz">mailto:foo@bar.baz</a></p>
+<p><a href="mailto:a.b-c_d@a.b">mailto:a.b-c_d@a.b</a></p>
+<p><a href="mailto:a.b-c_d@a.b">mailto:a.b-c_d@a.b</a>.</p>
+<p><a href="mailto:a.b-c_d@a.b">mailto:a.b-c_d@a.b</a>/</p>
+<p>mailto:a.b-c_d@a.b-</p>
+<p>mailto:a.b-c_d@a.b_</p>
+<p><a href="xmpp:foo@bar.baz">xmpp:foo@bar.baz</a></p>
+<p><a href="xmpp:foo@bar.baz">xmpp:foo@bar.baz</a>.</p>
+.
+
+A described in the specification xmpp offers an optional `/` followed by a resource.
+The resource can contain all alphanumeric characters, as well as `@` and `.`.
+<https://github.github.com/gfm/#example-634>
+.
+xmpp:foo@bar.baz/txt
+
+xmpp:foo@bar.baz/txt@bin
+
+xmpp:foo@bar.baz/txt@bin.com
+.
+<p><a href="xmpp:foo@bar.baz/txt">xmpp:foo@bar.baz/txt</a></p>
+<p><a href="xmpp:foo@bar.baz/txt@bin">xmpp:foo@bar.baz/txt@bin</a></p>
+<p><a href="xmpp:foo@bar.baz/txt@bin.com">xmpp:foo@bar.baz/txt@bin.com</a></p>
+.
+
+Further `/` characters are not considered part of the domain:
+.
+xmpp:foo@bar.baz/txt/bin
+.
+<p><a href="xmpp:foo@bar.baz/txt">xmpp:foo@bar.baz/txt</a>/bin</p>
+.

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -98,6 +98,12 @@ def test_footnote(file_params):
     assert file_params.assert_expected(md.render(file_params.content), rstrip=True)
 
 
+@pytest.mark.param_file(FIXTURE_PATH.joinpath("autolink_ext.md"))
+def test_autolink_ext(file_params):
+    md = MarkdownIt().enable("autolink_ext")
+    assert file_params.assert_expected(md.render(file_params.content), rstrip=True)
+
+
 @pytest.mark.param_file(FIXTURE_PATH.joinpath("ast.md"))
 def test_ast(file_params):
     md = MarkdownIt().enable_many(


### PR DESCRIPTION
Plugin which specifically adheres to https://github.github.com/gfm/#autolinks-extension-
It also replaces `linkify` for the `gfm` initial configuration, to more closely follow the GFM spec.

Note, currently there is one outstanding bug: https://github.com/chrisjsewell/markdown-it-plugins.rs/issues/13